### PR TITLE
Harmonises style across plots; Adds rounded barplot

### DIFF
--- a/exercises/solutions/actors.R
+++ b/exercises/solutions/actors.R
@@ -1,5 +1,6 @@
 library(ggplot2)
 library(dplyr)
+library(ggchicklet)
 
 movies <- read.csv("exercises/data/movie_metadata.csv")
 
@@ -7,26 +8,50 @@ movies_actors <- movies%>%
     group_by(aktor=actor_1_name)%>%
     summarise(ilosc=n())%>%
     arrange(desc(ilosc))%>%
-    head(6)
+    head(15)
+
+#ggplt <- 
+            ggplot(movies_actors,aes(x     =  reorder(aktor,ilosc), 
+                                     y     =  ilosc,
+                                     fill  =  ilosc)) +
+    
+            geom_chicklet(size   = 0.30,
+                          width   = 0.85,
+                          radius = unit(0.30, "cm"))  +
+
+            theme(text              = element_text(           color = "#4A637B", face = "bold", family = 'Helvetica')
+                  ,plot.caption     = element_text(size =  9, color = "#8d99ae", face = "plain"                     ) 
+                  ,plot.title       = element_text(size = 18, color = "#2b2d42", face = "bold", hjust=0.15          )
+                  ,axis.text.y      = element_text(size = 10, color = "#8d99ae", face = "bold", hjust=1.1           )
+                  ,axis.title.x     = element_text(size = 14 ,                                  hjust = 0.15        )
+                  ,axis.text.x      = element_blank()
+                  ,axis.title.y     = element_blank()
+                  ,axis.ticks.x     = element_blank()
+                  ,axis.ticks.y     = element_blank()
+                  ,plot.margin      = unit(c(1,1,1,1),"cm")
+                  ,panel.background = element_blank()
+                  ,legend.position  = "none"
+                  ,aspect.ratio     = 0.75) + 
+
+            scale_fill_gradient2(midpoint  = mean(movies_actors$ilosc) - 2,
+                                  low      = "#4974a5",
+                                  mid      = "#4A637B",
+                                  high     = "#f35f71",
+                                  space    = "Lab" ) +
+                
+            scale_size_continuous(range = c(3,5)) +
+            
+            coord_flip() +
+                
+            geom_text(aes(label = ilosc, 
+                          size  = ilosc),
+                      color     = "white",
+                      nudge_y   = -2.5,
+                      family    = 'Helvetica') +
+            
+            labs(title   = " Actors with most starring roles\n",
+                 caption = "\nsource: Spotkania Entuzjastów R-Warsaw RUG Meetup",
+                     y   = "\nNumber of starring roles")
 
 
-ggplot(movies_actors,aes(aktor,ilosc))+
-    geom_col(width = 0.8,fill="#f35f71")+
-    geom_text(aes(label=ilosc),nudge_y = -3, color="white",size=6)+
-    labs(title="starring roles",y="Number of starring roles")+
-    coord_flip()+
-    theme(
-        
-        plot.title = element_text(face="bold",size=24,color="#8d99ae",hjust=0.2),
-        plot.margin = unit(c(1,1,1,1),"cm"),
-        
-        panel.background = element_blank(),
-        
-        axis.ticks = element_blank(),
-        axis.title.y = element_blank(),
-        axis.text.y = element_text(size=16,color="#2b2d42",face="italic",hjust=1.1),
-        axis.title.x=element_text(size=18,hjust=0.2),
-        axis.text.x=element_blank(),
-        
-        aspect.ratio = 1
-    )
+

--- a/exercises/solutions/exercise_1.R
+++ b/exercises/solutions/exercise_1.R
@@ -42,12 +42,10 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
 
 
   # This is not redundant (cc' theme). See: https://github.com/tidyverse/ggplot2/issues/1859
-  geom_text(data     = countries[c(which.min(countries[["birth.rate"]]), which.max(countries[["birth.rate"]])),],
-            size     = 3,
-            vjust    = 1.5,
-            family   = "Helvetica",
-            fontface = "italic",
-            colour   = "#4A637B") +
+  geom_text(data          = countries[c(which.min(countries[["birth.rate"]]), which.max(countries[["birth.rate"]])),],
+            aes(colour    = birth.rate),
+            size          = 14,
+            family        = "Helvetica") +
 
   labs(
     title     = "Countries with the highest and lowest birth rate in the world",

--- a/exercises/solutions/exercise_1.R
+++ b/exercises/solutions/exercise_1.R
@@ -38,6 +38,9 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
                         high     = "#f35f71",
                         space    = "Lab" ) +
 
+  scale_size_continuous(range = c(0.05,3)) +
+
+
   # This is not redundant (cc' theme). See: https://github.com/tidyverse/ggplot2/issues/1859
   geom_text(data     = countries[c(which.min(countries[["birth.rate"]]), which.max(countries[["birth.rate"]])),],
             size     = 3,

--- a/exercises/solutions/exercise_1.R
+++ b/exercises/solutions/exercise_1.R
@@ -68,6 +68,7 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
         ,plot.title      = element_text(size  = 14,hjust = 0 )
         ,plot.subtitle   = element_text(size  =  7,hjust = 1,face = "italic")
         ,plot.caption    = element_text(size  =  7)
+        ,panel.background = element_rect(fill = "white")
         ,legend.position = "none")
 
 

--- a/exercises/solutions/exercise_1.R
+++ b/exercises/solutions/exercise_1.R
@@ -47,6 +47,12 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
             size          = 14,
             family        = "Helvetica") +
 
+  # Add Poland and Greece
+  geom_text(data          = countries[countries[["country"]] %in% c("Greece", "Poland"), ],
+            aes(colour    = birth.rate),
+            size          = 3,
+            family        = "Helvetica") +
+
   labs(
     title     = "Countries with the highest and lowest birth rate in the world",
     subtitle  = "12.12.19: Statistical inference with missing values + ggplot2 workshops",

--- a/exercises/solutions/exercise_1.R
+++ b/exercises/solutions/exercise_1.R
@@ -32,6 +32,12 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
 
   geom_point() +
 
+  scale_color_gradient2(midpoint = mean(countries$birth.rate),
+                        low      = "#4974a5",
+                        mid      = "#4A637B",
+                        high     = "#f35f71",
+                        space    = "Lab" ) +
+
   # This is not redundant (cc' theme). See: https://github.com/tidyverse/ggplot2/issues/1859
   geom_text(data     = countries[c(which.min(countries[["birth.rate"]]), which.max(countries[["birth.rate"]])),],
             size     = 3,
@@ -55,12 +61,7 @@ ggplt <- ggplot(countries, aes(x     = death.rate,
         ,plot.title      = element_text(size  = 14,hjust = 0 )
         ,plot.subtitle   = element_text(size  =  7,hjust = 1,face = "italic")
         ,plot.caption    = element_text(size  =  7)
-        ,legend.position = "none") +
+        ,legend.position = "none")
 
-  scale_color_gradient2(midpoint = mean(countries$birth.rate),
-                        low      = "#4974a5",
-                        mid      = "#4A637B",
-                        high     = "#f35f71",
-                        space    = "Lab" )
 
 plotly::ggplotly(ggplt, tooltip = c("x","y","country"))


### PR DESCRIPTION
This PR adds one more plot customisations to harmonise the style across plots and refine details (eg. control of aes size range, rounded barplot, control of tooltip displayed info)

|  [exercises/solutions/exercise_1.R `(plotly)`](https://github.com/cgpu/12-12-2019-ggplot2-workshop/blob/497f108ad4801dec50191f343e0b166c5d06ea73/exercises/solutions/exercise_1.R) |  [exercises/solutions/actors.R](https://github.com/cgpu/12-12-2019-ggplot2-workshop/blob/497f108ad4801dec50191f343e0b166c5d06ea73/exercises/solutions/actors.R) |
|:---|:---|
|  ![image](https://user-images.githubusercontent.com/38183826/71757712-b039cb00-2e8f-11ea-8a14-924619d57fd5.png) | ![image](https://user-images.githubusercontent.com/38183826/71757715-c5165e80-2e8f-11ea-8f65-b87648279b07.png)  